### PR TITLE
fix events

### DIFF
--- a/lib/ruff.js
+++ b/lib/ruff.js
@@ -7,9 +7,10 @@
         global.ruff = new Ruff();
     
     function Ruff() {
+        var events = new Events();
+
         function ra(generator) {
-            var gen     = generator(),
-                events  = new Events();
+            var gen     = generator();
             
             function nextItem(error, result) {
                 var item = gen.next(result);
@@ -33,14 +34,14 @@
         }
         
         Events.prototype.on = function(event, callback) {
-            var funcs = Events[event];
+            var funcs = this._all[event];
             
             if (funcs)
                 funcs.push(callback);
             else
                 this._all[event] = [callback];
             
-            return ra;
+            return events;
         };
         
         Events.prototype.emit = function(event, data) {


### PR DESCRIPTION
This snipped:

``` js
var ruff    = require('./lib/ruff'),
    minify  = require('minify');

ruff(function*() {
    var mini        = minify.bind(null, 'lib/not_ruff.js'),
        result      = yield mini;

    console.log(result)
}).on('end', function(data) {
    console.log(1);
}).on('end', function() {
    console.log('foo');
}).on('error', function(error) {
    console.log('Err:', error);
});
```

caused an error:

```
TypeError: Object function ra(generator) {
      var gen = generator(), events = new Events();

      function nextItem(error, result) {
        var item = gen.next(result);

        if (error) events.emit("error", error);else if (!item.done) item.value(nextItem);

        if (item.done) events.emit("end");
      }

      nextItem();

      return events;
    } has no method 'on'
```

Because you returned `ra` in `on` and not `event`. 
